### PR TITLE
Fix typo in ModFile property

### DIFF
--- a/src/objects/ModFile.ts
+++ b/src/objects/ModFile.ts
@@ -24,7 +24,7 @@ export default class ModFile extends CFObject {
     public readonly fileLength: bigint;
     public readonly downloadCount: bigint;
     public readonly downloadUrl: string;
-    public readonly gameVersion: string[];
+    public readonly gameVersions: string[];
     public readonly sortableGameVersions: SortableGameVersion[];
     public readonly dependencies: FileDependency[];
     public readonly exposeAsAlternative: boolean | null;
@@ -51,7 +51,7 @@ export default class ModFile extends CFObject {
         this.fileLength = data.fileLength;
         this.downloadCount = data.downloadCount;
         this.downloadUrl = data.downloadUrl;
-        this.gameVersion = data.gameVersion;
+        this.gameVersions = data.gameVersions;
         this.sortableGameVersions = data.sortableGameVersions;
         this.dependencies = data.dependencies;
         this.exposeAsAlternative = data.exposeAsAlternative;


### PR DESCRIPTION
According to the [API docs](https://docs.curseforge.com/#get-mod-file) this property is called `gameVersions` instead of `gameVersion`, it was probably a typo, but it was causing it to be undefined instead of a correct string array

if I need to change something else in the code feel free to tell me about it or just edit the PR however you want