### PR TITLE
Add get_files() parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as utils from "./utils";
 import { URL } from "url";
 import { ErrorBadRequest, ErrorInternalServer, ErrorNotFound } from "./objects/exceptions";
 import { FingerprintFuzzyMatch, FingerprintMatchResult, FolderFingerprints, GameVersionsByType, GameVersionType, Pagination, PagingOptions, SearchOptions } from "./objects/types";
+import { ModLoaderType } from "./objects/enums";
 
 export {Game, Mod, Category, ModFile, types as Types, exceptions as Exceptions, enums as Enums};
 
@@ -335,11 +336,13 @@ class Curseforge {
         });
     }
 
-    public get_files(mod: Mod | number, searchOptions?: {gameVersionTypeId?: number} & PagingOptions): Promise<ModFile[] & {"paging": Pagination}> {
+    public get_files(mod: Mod | number, searchOptions?: {gameVersion?: string, modLoaderType?: ModLoaderType | number, gameVersionTypeId?: number} & PagingOptions): Promise<ModFile[] & {"paging": Pagination}> {
         return new Promise(async (resolve, reject) => {
             let uri = new URL(this.API_URL + "mods/" + utils.cleanse(mod) + "/files");
 
             if(searchOptions){
+                if(searchOptions.gameVersion) uri.searchParams.set("gameVersion", searchOptions.gameVersion);
+                if(searchOptions.modLoaderType) uri.searchParams.set("modLoaderType", searchOptions.modLoaderType.toString())
                 if(searchOptions.gameVersionTypeId) uri.searchParams.set("gameVersionTypeId", searchOptions.gameVersionTypeId.toString());
                 if(searchOptions.index) uri.searchParams.set("index", searchOptions.index.toString());
                 if(searchOptions.pageSize) uri.searchParams.set("pageSize", searchOptions.pageSize.toString());

--- a/src/objects/Mod.ts
+++ b/src/objects/Mod.ts
@@ -1,6 +1,6 @@
 import { Category, ModFile } from ".";
 import Curseforge from "..";
-import { ModStatus } from "./enums";
+import { ModLoaderType, ModStatus } from "./enums";
 import { CFObject } from "./interfaces";
 import { FileIndex, ModAsset, ModAuthor, ModLinks, Pagination, PagingOptions } from "./types";
 
@@ -144,7 +144,7 @@ export default class Mod extends CFObject {
      * @param searchOptions Options to use when getting the files for this mod.
      * @returns mod files found using this method.
      */
-    public get_files(searchOptions?: {gameVersionTypeId?: number} & PagingOptions): Promise<ModFile[] & {"paging": Pagination}> {
+    public get_files(searchOptions?: {gameVersion?: string, modLoaderType?: ModLoaderType | number, gameVersionTypeId?: number} & PagingOptions): Promise<ModFile[] & {"paging": Pagination}> {
         return this._client.get_files(this.id, searchOptions);
     }
 


### PR DESCRIPTION
The `get_files` function of `Mod` is currently missing the `gameVersion` and `modLoaderType` keys from the `searchOptions` parameter.

This adds the 2 missing keys to match the [CurseForge API](https://docs.curseforge.com/#get-mod-files).