### PR TITLE
Fix `get_file_changelog` endpoint according to CF Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ etc/
 # User Settings
 .vscode/
 
+# jetbrains files
+.idea
+
 *.user.config
 
 yarn.lock

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,7 @@ class Curseforge {
 
     public get_file_changelog(mod: Mod | number, file: ModFile | number): Promise<string> {
         return new Promise(async (resolve, reject) => {
-            let res = await utils.get(this.API_URL + "mods/" + utils.cleanse(mod) + "/files/" + utils.cleanse(file));
+            let res = await utils.get(this.API_URL + "mods/" + utils.cleanse(mod) + "/files/" + utils.cleanse(file) + "/changelog");
             switch(res.code){
                 case 200:
                     resolve(res.data.data);

--- a/src/objects/Mod.ts
+++ b/src/objects/Mod.ts
@@ -131,7 +131,7 @@ export default class Mod extends CFObject {
         this.logo = data.logo;
         this.thumbnails = data.thumbnails;
         this.mainFileId = data.mainFileId;
-        this.latestFiles = data.latestFiles;
+        this.latestFiles = data.latestFiles.map((file: any) => new ModFile(_client, file));
         this.latestFilesIndexes = data.latestFilesIndexes;
         this.dateCreated = new Date(data.dateCreated);
         this.dateModified = new Date(data.dateModified);


### PR DESCRIPTION
Reference: https://docs.curseforge.com/#get-mod-file-changelog

Also fixes latestFiles ModFile initialization so that methods like get_changelog can be called on those objects - Fixes #13 